### PR TITLE
Fix windows 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It has many uses, such as:
 - Getting a higher resolution (or higher refresh rate) display when you don't have a physical one on-hand (though note you can only use it in software/VR)
 - Other uses? Let me know!
 
-Support: Windows 10 x64 +
+Supports: Windows 10 version 2004+ (x64 only)
 
 _For any bug reports, please see the [debugging or reporting crashes](https://github.com/MolotovCherry/virtual-display-rs#debugging-or-reporting-crashes) section to get the panic message for the bug report_
 

--- a/virtual-display-driver/Makefile.toml
+++ b/virtual-display-driver/Makefile.toml
@@ -101,7 +101,7 @@ dependencies = ["build-driver", "rename", "stamp-inf", "sign"]
 script = [
     # generate and sign cat file
     '''
-    inf2cat /driver:%BUILD_TARGET_PATH% /os:10_x64
+    inf2cat /driver:%BUILD_TARGET_PATH% /os:10_x64,10_AU_X64,10_RS2_X64,10_RS3_X64,10_RS4_X64,10_RS5_X64,10_19H1_X64,10_VB_X64,10_CO_X64,10_NI_X64
 
     signtool sign /a /fd SHA256 /v %SIGN_OPTIONS% /t http://timestamp.digicert.com "%BUILD_TARGET_PATH%/%CAT_FILE%"
     ''',

--- a/wdf-umdf-sys/build.rs
+++ b/wdf-umdf-sys/build.rs
@@ -64,8 +64,8 @@ pub fn get_um_dir(dir_type: DirectoryType) -> Result<PathBuf, Error> {
 
 pub fn get_umdf_dir(dir_type: DirectoryType) -> Result<PathBuf, Error> {
     Ok(get_windows_kits_dir()?.join(match dir_type {
-        DirectoryType::Include => PathBuf::from_iter(["Include", "wdf", "umdf", "2.33"]),
-        DirectoryType::Library => PathBuf::from_iter(["Lib", "wdf", "umdf", "x64", "2.33"]),
+        DirectoryType::Include => PathBuf::from_iter(["Include", "wdf", "umdf", "2.31"]),
+        DirectoryType::Library => PathBuf::from_iter(["Lib", "wdf", "umdf", "x64", "2.31"]),
     }))
 }
 
@@ -131,7 +131,7 @@ fn generate() {
 
     let mut iddcx_lib_dir = lib_um_dir.clone();
     iddcx_lib_dir.push("iddcx");
-    iddcx_lib_dir.push("1.9");
+    iddcx_lib_dir.push("1.4");
 
     println!("cargo:rustc-link-search={}", iddcx_lib_dir.display());
 

--- a/wdf-umdf-sys/c/wrapper.h
+++ b/wdf-umdf-sys/c/wrapper.h
@@ -21,4 +21,4 @@
 
 #define IDD_STUB
 
-#include <iddcx\1.9\IddCx.h>
+#include <iddcx\1.4\IddCx.h>

--- a/wdf-umdf-sys/src/bindings.rs
+++ b/wdf-umdf-sys/src/bindings.rs
@@ -11,4 +11,4 @@ unsafe impl Sync for _WDF_OBJECT_CONTEXT_TYPE_INFO {}
 
 // fails to build without this symbol
 #[no_mangle]
-pub static IddMinimumVersionRequired: ULONG = 6;
+pub static IddMinimumVersionRequired: ULONG = 4;

--- a/wdf-umdf/src/wdf.rs
+++ b/wdf-umdf/src/wdf.rs
@@ -62,7 +62,7 @@ macro_rules! WdfCall {
 
                 if is_available {
                     // SAFETY: Only immutable accesses are done to this
-                    let fn_table = unsafe { ::wdf_umdf_sys::WdfFunctions_02033 };
+                    let fn_table = unsafe { ::wdf_umdf_sys::WdfFunctions_02031 };
 
                     // SAFETY: Read-only, initialized by the time we use it, and checked to be in bounds
                     let fn_handle = unsafe {


### PR DESCRIPTION
Accidentally was using api's only supported on Win11. Use older version apis which support Windows 10 also now.

Fixes #14 

