### PR TITLE
Use `copy` instead of `cp` in build script

### DIFF
--- a/virtual-display-driver/Makefile.toml
+++ b/virtual-display-driver/Makefile.toml
@@ -71,7 +71,7 @@ CAT_FILE = "VirtualDisplayDriver.cat"
 env = { "BUILD_TARGET_PATH" = { script = ['''
     for /f "tokens=*" %%a in ('cargo target-dir') do set target_dir=%%a
 
-    echo %target_dir%/%TARGET_PATH%
+    echo %target_dir%\%TARGET_PATH%
 '''] } }
 
 [tasks.build-driver]
@@ -141,9 +141,9 @@ script = [
     ''',
     # copy output files to it
     '''
-        cp %BUILD_TARGET_PATH%/*.dll ../target/output
-        cp %BUILD_TARGET_PATH%/*.inf ../target/output
-        cp %BUILD_TARGET_PATH%/*.cat ../target/output
+        copy %BUILD_TARGET_PATH%\*.dll ..\target\output
+        copy %BUILD_TARGET_PATH%\*.inf ..\target\output
+        copy %BUILD_TARGET_PATH%\*.cat ..\target\output
     ''',
 ]
 


### PR DESCRIPTION
I followed along with the build instructions listed in the Readme, but I ran into the following error in the `tasks.copy` build step:

```
C:\path\to\virtual-display-rs\virtual-display-driver>cp C:\path\to\virtual-display-rs\target/x86_64-pc-windows-msvc\debug/*.dll ../target/output
'cp' is not recognized as an internal or external command,
operable program or batch file.

C:\path\to\virtual-display-rs\virtual-display-driver>cp C:\path\to\virtual-display-rs\target/x86_64-pc-windows-msvc\debug/*.inf ../target/output
'cp' is not recognized as an internal or external command,
operable program or batch file.

C:\path\to\virtual-display-rs\virtual-display-driver>cp C:\path\to\virtual-display-rs\target/x86_64-pc-windows-msvc\debug/*.cat ../target/output
'cp' is not recognized as an internal or external command,
operable program or batch file.
[cargo-make][1] ERROR - Error while executing command, exit code: 1
[cargo-make][1] WARN - Build Failed.
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```

I'm guessing that this build is normally run in a Cygwin or MSYS2 environment? With this change, I was able to get the driver to build in a vanilla PowerShell environment.

---

In light of the conversation in #45, I'm going to include this boilerplate just to make it clear I'm open to this change being relicensed:

> I affirm that I own the copyright to the changes in this pull request, and I grant permission to @MolotovCherry to redistribute, republish, and reuse the code and changes within without restrictions, including for the purpose of redistributing and relicensing the `virtual-display-rs` project under any license terms.