### PR TITLE
Fix Clippy warnings in CLI

### DIFF
--- a/virtual-display-driver-cli/src/client.rs
+++ b/virtual-display-driver-cli/src/client.rs
@@ -67,22 +67,19 @@ impl Client {
     pub fn new_id(&mut self, preferred_id: Option<driver_ipc::Id>) -> eyre::Result<driver_ipc::Id> {
         let monitors = self.list()?;
 
-        match preferred_id {
-            Some(id) => {
-                if monitors.iter().any(|monitor| monitor.id == id) {
-                    eyre::bail!("monitor with ID {} already exists", id);
-                }
+        if let Some(id) = preferred_id {
+            if monitors.iter().any(|monitor| monitor.id == id) {
+                eyre::bail!("monitor with ID {} already exists", id);
+            }
 
-                Ok(id)
-            }
-            None => {
-                let max_id = monitors.iter().map(|monitor| monitor.id).max();
-                let id = match max_id {
-                    Some(id) => id + 1,
-                    None => 0,
-                };
-                Ok(id)
-            }
+            Ok(id)
+        } else {
+            let max_id = monitors.iter().map(|monitor| monitor.id).max();
+            let id = match max_id {
+                Some(id) => id + 1,
+                None => 0,
+            };
+            Ok(id)
         }
     }
 

--- a/virtual-display-driver-cli/src/main.rs
+++ b/virtual-display-driver-cli/src/main.rs
@@ -35,7 +35,7 @@ enum Command {
     RemoveMode(RemoveModeCommand),
     /// Enable a virtual monitor.
     Enable(EnableCommand),
-    /// Disable one or more virtual monitors.
+    /// Disable a virtual monitor.
     Disable(DisableCommand),
     /// Remove one or more virtual monitors.
     Remove(RemoveCommand),

--- a/virtual-display-driver-cli/src/main.rs
+++ b/virtual-display-driver-cli/src/main.rs
@@ -9,12 +9,18 @@ mod client;
 
 #[derive(Debug, Parser)]
 struct Args {
-    /// Format output as JSON.
-    #[clap(short, long)]
-    json: bool,
+    #[clap(flatten)]
+    options: GlobalOptions,
 
     #[clap(subcommand)]
     command: Command,
+}
+
+#[derive(Debug, Parser)]
+struct GlobalOptions {
+    /// Format output as JSON.
+    #[clap(short, long)]
+    json: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -22,295 +28,356 @@ enum Command {
     /// List currently connected virtual monitors.
     List,
     /// Add a new virtual monitor.
-    Add {
-        /// Width of the virtual monitor.
-        width: driver_ipc::Dimen,
-
-        /// Height of the virtual monitor.
-        height: driver_ipc::Dimen,
-
-        /// More resolutions to add as extra modes for the virtual monitor.
-        more_widths_and_heights: Vec<driver_ipc::Dimen>,
-
-        /// Refresh rate of the virtual monitor. Pass multiple times to
-        /// support multiple refresh rates.
-        #[clap(short, long, default_value = "60")]
-        refresh_rate: Vec<driver_ipc::RefreshRate>,
-
-        /// Manual ID to set for the monitor. Must not conflict with an
-        /// existing virtual monitor's ID.
-        #[clap(long)]
-        id: Option<driver_ipc::Id>,
-
-        /// Optional label for the virtual monitor.
-        #[clap(long)]
-        name: Option<String>,
-
-        /// Set the virtual monitor to disabled on creation.
-        #[clap(long)]
-        disabled: bool,
-    },
+    Add(AddCommand),
     /// Add a new resolution/refresh rate mode to an existing virtual monitor.
-    AddMode {
-        /// ID of the virtual monitor to add a mode to.
-        id: driver_ipc::Id,
-
-        /// Width of the new mode.
-        width: driver_ipc::Dimen,
-
-        /// Height of the new mode.
-        height: driver_ipc::Dimen,
-
-        /// Refresh rate for the new mode. Pass multiple times to support
-        /// multiple refresh rates in this mode.
-        #[clap(short, long, default_value = "60")]
-        refresh_rate: Vec<driver_ipc::RefreshRate>,
-    },
+    AddMode(AddModeCommand),
     /// Remove a resolution/refresh rate mode to an existing virtual monitor.
-    RemoveMode {
-        /// ID of the virtual monitor to add a mode to.
-        id: driver_ipc::Id,
-
-        /// The index of the mode to remove.
-        mode_index: usize,
-    },
+    RemoveMode(RemoveModeCommand),
     /// Enable a virtual monitor.
-    Enable { id: driver_ipc::Id },
+    Enable(EnableCommand),
     /// Disable one or more virtual monitors.
-    Disable { id: driver_ipc::Id },
+    Disable(DisableCommand),
     /// Remove one or more virtual monitors.
-    Remove { id: Vec<driver_ipc::Id> },
+    Remove(RemoveCommand),
     /// Remove all virtual monitors.
     RemoveAll,
 }
 
+#[derive(Debug, Parser)]
+struct AddCommand {
+    /// Width of the virtual monitor.
+    width: driver_ipc::Dimen,
+
+    /// Height of the virtual monitor.
+    height: driver_ipc::Dimen,
+
+    /// More resolutions to add as extra modes for the virtual monitor.
+    more_widths_and_heights: Vec<driver_ipc::Dimen>,
+
+    /// Refresh rate of the virtual monitor. Pass multiple times to
+    /// support multiple refresh rates.
+    #[clap(short, long, default_value = "60")]
+    refresh_rate: Vec<driver_ipc::RefreshRate>,
+
+    /// Manual ID to set for the monitor. Must not conflict with an
+    /// existing virtual monitor's ID.
+    #[clap(long)]
+    id: Option<driver_ipc::Id>,
+
+    /// Optional label for the virtual monitor.
+    #[clap(long)]
+    name: Option<String>,
+
+    /// Set the virtual monitor to disabled on creation.
+    #[clap(long)]
+    disabled: bool,
+}
+
+#[derive(Debug, Parser)]
+struct AddModeCommand {
+    /// ID of the virtual monitor to add a mode to.
+    id: driver_ipc::Id,
+
+    /// Width of the new mode.
+    width: driver_ipc::Dimen,
+
+    /// Height of the new mode.
+    height: driver_ipc::Dimen,
+
+    /// Refresh rate for the new mode. Pass multiple times to support
+    /// multiple refresh rates in this mode.
+    #[clap(short, long, default_value = "60")]
+    refresh_rate: Vec<driver_ipc::RefreshRate>,
+}
+
+#[derive(Debug, Parser)]
+struct RemoveModeCommand {
+    /// ID of the virtual monitor to add a mode to.
+    id: driver_ipc::Id,
+
+    /// The index of the mode to remove.
+    mode_index: usize,
+}
+
+#[derive(Debug, Parser)]
+struct EnableCommand {
+    id: driver_ipc::Id,
+}
+
+#[derive(Debug, Parser)]
+struct DisableCommand {
+    id: driver_ipc::Id,
+}
+
+#[derive(Debug, Parser)]
+struct RemoveCommand {
+    id: Vec<driver_ipc::Id>,
+}
+
 fn main() -> eyre::Result<()> {
-    let args = Args::parse();
+    let Args { options, command } = Args::parse();
 
-    match args.command {
+    match command {
         Command::List => {
-            let mut client = Client::connect()?;
-
-            let monitors = client.list()?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &monitors)?;
-            } else {
-                if monitors.len() > 0 {
-                    println!("{}", "Virtual monitors".underline());
-                    for (i, monitor) in monitors.iter().enumerate() {
-                        if i > 0 {
-                            println!();
-                        }
-
-                        let name_label = lazy_format!(match (&monitor.name) {
-                            Some(name) => (" {}{name}{}", "[".dimmed(), "]".dimmed()),
-                            None => "",
-                        });
-                        let disabled_label = lazy_format!(if monitor.enabled => ""
-                        else =>
-                            (" {}", "(disabled)".red())
-                        );
-                        println!(
-                            "Monitor {}{name_label}{disabled_label}:",
-                            monitor.id.green(),
-                        );
-
-                        if monitor.modes.len() > 0 {
-                            for (index, mode) in monitor.modes.iter().enumerate() {
-                                let refresh_rate_labels = mode
-                                    .refresh_rates
-                                    .iter()
-                                    .map(|rate| lazy_format!("{}", rate.blue()))
-                                    .join_with("/");
-                                let refresh_rates = lazy_format!(if mode.refresh_rates.is_empty() =>
-                                    ("{}Hz", "?".red())
-                                else =>
-                                    ("{}Hz", refresh_rate_labels)
-                                );
-                                println!(
-                                    "{} Mode {index}: {}x{} @ {}",
-                                    "-".dimmed(),
-                                    mode.width.green(),
-                                    mode.height.green(),
-                                    refresh_rates
-                                );
-                            }
-                        } else {
-                            println!("{} {}", "-".dimmed(), "No modes".red());
-                        }
-                    }
-                } else {
-                    println!("No virtual monitors found.");
-                }
-            }
+            list(&options)?;
         }
-        Command::Add {
-            width,
-            height,
-            more_widths_and_heights,
-            refresh_rate,
-            id,
-            name,
-            disabled,
-        } => {
-            if more_widths_and_heights.len() % 2 != 0 {
-                eyre::bail!("passed a width for an extra resolution without a height");
-            }
-
-            let modes = std::iter::once(&[width, height][..])
-                .chain(more_widths_and_heights.chunks_exact(2))
-                .map(|dim| driver_ipc::Mode {
-                    width: dim[0],
-                    height: dim[1],
-                    refresh_rates: refresh_rate.clone(),
-                })
-                .collect();
-
-            let mut client = Client::connect()?;
-            let id = client.new_id(id)?;
-            let new_monitor = driver_ipc::Monitor {
-                id,
-                enabled: !disabled,
-                name,
-                modes,
-            };
-            client.notify(vec![new_monitor])?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &id)?;
-            } else {
-                let disabled_footnote = lazy_format!(
-                    if disabled => (" {}", "(disabled)".red())
-                    else => ""
-                );
-                println!(
-                    "Added virtual monitor with ID {}{disabled_footnote}.",
-                    id.green()
-                );
-            }
+        Command::Add(command) => {
+            add(&options, command)?;
         }
-        Command::AddMode {
-            id,
-            width,
-            height,
-            refresh_rate,
-        } => {
-            let mut client = Client::connect()?;
-            let mut monitor = client.get(id)?;
-
-            let new_mode_index = monitor.modes.len();
-            let new_mode = driver_ipc::Mode {
-                width,
-                height,
-                refresh_rates: refresh_rate,
-            };
-            monitor.modes.push(new_mode);
-            client.notify(vec![monitor])?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &new_mode_index)?;
-            } else {
-                println!(
-                    "Added new mode {} to virtual monitor with ID {}.",
-                    new_mode_index.blue(),
-                    id.green()
-                );
-            }
+        Command::AddMode(command) => {
+            add_mode(&options, command)?;
         }
-        Command::RemoveMode { id, mode_index } => {
-            let mut client = Client::connect()?;
-            let mut monitor = client.get(id)?;
-
-            if mode_index >= monitor.modes.len() {
-                eyre::bail!(
-                    "virtual monitor with ID {} has no mode with index {}",
-                    id,
-                    mode_index
-                );
-            }
-            if monitor.modes.len() == 1 {
-                eyre::bail!(
-                    "cannot remove last mode from virtual monitor with ID {}",
-                    id
-                );
-            }
-
-            monitor.modes.remove(mode_index);
-            client.notify(vec![monitor])?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &mode_index)?;
-            } else {
-                println!(
-                    "Removed mode {} from virtual monitor with ID {}.",
-                    mode_index.blue(),
-                    id.green()
-                );
-            }
+        Command::RemoveMode(command) => {
+            remove_mode(&options, &command)?;
         }
-        Command::Enable { id } => {
-            let mut client = Client::connect()?;
-            let outcome = set_enabled(&mut client, id, true)?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &outcome)?;
-            } else {
-                let footnote = if outcome.toggled {
-                    ""
-                } else {
-                    " (was already enabled)"
-                };
-                println!("Enabled virtual monitor with ID {}{footnote}.", id.green());
-            }
+        Command::Enable(command) => {
+            enable(&options, &command)?;
         }
-        Command::Disable { id } => {
-            let mut client = Client::connect()?;
-            let outcome = set_enabled(&mut client, id, false)?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &outcome)?;
-            } else {
-                let footnote = if outcome.toggled {
-                    ""
-                } else {
-                    " (was already disabled)"
-                };
-                println!("Disabled virtual monitor with ID {}{footnote}.", id.green());
-            }
+        Command::Disable(command) => {
+            disable(&options, &command)?;
         }
-        Command::Remove { id } => {
-            let mut client = Client::connect()?;
-            client.remove(id.clone())?;
-
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &id)?;
-            } else {
-                if id.len() == 1 {
-                    println!("Removed virtual monitor.");
-                } else {
-                    println!("Removed {} virtual monitors.", id.len());
-                }
-            }
+        Command::Remove(command) => {
+            remove(&options, &command)?;
         }
         Command::RemoveAll => {
-            let mut client = Client::connect()?;
-            client.remove_all()?;
+            remove_all(&options)?;
+        }
+    }
 
-            if args.json {
-                let mut stdout = std::io::stdout().lock();
-                serde_json::to_writer_pretty(&mut stdout, &())?;
+    Ok(())
+}
+
+fn list(opts: &GlobalOptions) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+
+    let monitors = client.list()?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &monitors)?;
+    } else if !monitors.is_empty() {
+        println!("{}", "Virtual monitors".underline());
+        for (i, monitor) in monitors.iter().enumerate() {
+            if i > 0 {
+                println!();
+            }
+
+            let name_label = lazy_format!(match (&monitor.name) {
+                Some(name) => (" {}{name}{}", "[".dimmed(), "]".dimmed()),
+                None => "",
+            });
+            let disabled_label = lazy_format!(if monitor.enabled => ""
+            else =>
+                (" {}", "(disabled)".red())
+            );
+            println!(
+                "Monitor {}{name_label}{disabled_label}:",
+                monitor.id.green(),
+            );
+
+            if monitor.modes.is_empty() {
+                println!("{} {}", "-".dimmed(), "No modes".red());
             } else {
-                println!("Removed all virtual monitors.");
+                for (index, mode) in monitor.modes.iter().enumerate() {
+                    let refresh_rate_labels = mode
+                        .refresh_rates
+                        .iter()
+                        .map(|rate| lazy_format!("{}", rate.blue()))
+                        .join_with("/");
+                    let refresh_rates = lazy_format!(if mode.refresh_rates.is_empty() =>
+                        ("{}Hz", "?".red())
+                    else =>
+                        ("{}Hz", refresh_rate_labels)
+                    );
+                    println!(
+                        "{} Mode {index}: {}x{} @ {}",
+                        "-".dimmed(),
+                        mode.width.green(),
+                        mode.height.green(),
+                        refresh_rates
+                    );
+                }
             }
         }
+    } else {
+        println!("No virtual monitors found.");
+    }
+
+    Ok(())
+}
+
+fn add(opts: &GlobalOptions, command: AddCommand) -> eyre::Result<()> {
+    if command.more_widths_and_heights.len() % 2 != 0 {
+        eyre::bail!("passed a width for an extra resolution without a height");
+    }
+
+    let modes = std::iter::once(&[command.width, command.height][..])
+        .chain(command.more_widths_and_heights.chunks_exact(2))
+        .map(|dim| driver_ipc::Mode {
+            width: dim[0],
+            height: dim[1],
+            refresh_rates: command.refresh_rate.clone(),
+        })
+        .collect();
+
+    let mut client = Client::connect()?;
+    let id = client.new_id(command.id)?;
+    let new_monitor = driver_ipc::Monitor {
+        id,
+        enabled: !command.disabled,
+        name: command.name,
+        modes,
+    };
+    client.notify(vec![new_monitor])?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &id)?;
+    } else {
+        let disabled_footnote = lazy_format!(
+            if command.disabled => (" {}", "(disabled)".red())
+            else => ""
+        );
+        println!(
+            "Added virtual monitor with ID {}{disabled_footnote}.",
+            id.green()
+        );
+    }
+
+    Ok(())
+}
+
+fn add_mode(opts: &GlobalOptions, command: AddModeCommand) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+    let mut monitor = client.get(command.id)?;
+
+    let new_mode_index = monitor.modes.len();
+    let new_mode = driver_ipc::Mode {
+        width: command.width,
+        height: command.height,
+        refresh_rates: command.refresh_rate,
+    };
+    monitor.modes.push(new_mode);
+    client.notify(vec![monitor])?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &new_mode_index)?;
+    } else {
+        println!(
+            "Added new mode {} to virtual monitor with ID {}.",
+            new_mode_index.blue(),
+            command.id.green()
+        );
+    }
+
+    Ok(())
+}
+
+fn remove_mode(opts: &GlobalOptions, command: &RemoveModeCommand) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+    let mut monitor = client.get(command.id)?;
+
+    if command.mode_index >= monitor.modes.len() {
+        eyre::bail!(
+            "virtual monitor with ID {} has no mode with index {}",
+            command.id,
+            command.mode_index
+        );
+    }
+    if monitor.modes.len() == 1 {
+        eyre::bail!(
+            "cannot remove last mode from virtual monitor with ID {}",
+            command.id
+        );
+    }
+
+    monitor.modes.remove(command.mode_index);
+    client.notify(vec![monitor])?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &command.mode_index)?;
+    } else {
+        println!(
+            "Removed mode {} from virtual monitor with ID {}.",
+            command.mode_index.blue(),
+            command.id.green()
+        );
+    }
+
+    Ok(())
+}
+
+fn enable(opts: &GlobalOptions, command: &EnableCommand) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+    let outcome = set_enabled(&mut client, command.id, true)?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &outcome)?;
+    } else {
+        let footnote = if outcome.toggled {
+            ""
+        } else {
+            " (was already enabled)"
+        };
+        println!(
+            "Enabled virtual monitor with ID {}{footnote}.",
+            command.id.green()
+        );
+    }
+
+    Ok(())
+}
+
+fn disable(opts: &GlobalOptions, command: &DisableCommand) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+    let outcome = set_enabled(&mut client, command.id, false)?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &outcome)?;
+    } else {
+        let footnote = if outcome.toggled {
+            ""
+        } else {
+            " (was already disabled)"
+        };
+        println!(
+            "Disabled virtual monitor with ID {}{footnote}.",
+            command.id.green()
+        );
+    }
+
+    Ok(())
+}
+
+fn remove(opts: &GlobalOptions, command: &RemoveCommand) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+    client.remove(command.id.clone())?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &command.id)?;
+    } else if command.id.len() == 1 {
+        println!("Removed virtual monitor.");
+    } else {
+        println!("Removed {} virtual monitors.", command.id.len());
+    }
+
+    Ok(())
+}
+
+fn remove_all(opts: &GlobalOptions) -> eyre::Result<()> {
+    let mut client = Client::connect()?;
+    client.remove_all()?;
+
+    if opts.json {
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &())?;
+    } else {
+        println!("Removed all virtual monitors.");
     }
 
     Ok(())


### PR DESCRIPTION
I started looking at some of the issues from #48, and as I started getting things set up, I noticed that there were some Clippy lints that were failing on `master`. I decided to make this small PR mainly just to get fixes in for all the lints. Part of this was breaking out the `main` function into smaller pieces, so that involved a bit of restructuring as well.

Oh, and I also realized that there was a bit of the help text on the CLI that wasn't accurate, so I made sure to fix that too.