### PR TITLE
Improve connection handling in CLI app with a few minor tweaks

### DIFF
--- a/virtual-display-driver-cli/src/client.rs
+++ b/virtual-display-driver-cli/src/client.rs
@@ -16,7 +16,8 @@ impl Client {
                 .wait()
                 .access_duplex()
                 .mode_message()
-                .create()?;
+                .create()
+                .context("Failed to connect to Virtual Display Driver; please ensure the driver is installed and working. Other program using the driver must also be closed, such as the Virtual Display Driver Control app.")?;
 
         send_command(&mut writer, &driver_ipc::Command::RequestState)?;
         let state = receive_command(&mut reader)?;

--- a/virtual-display-driver-cli/src/client.rs
+++ b/virtual-display-driver-cli/src/client.rs
@@ -5,37 +5,37 @@ use eyre::Context;
 use win_pipes::{NamedPipeClientReader, NamedPipeClientWriter};
 
 pub struct Client {
-    reader: NamedPipeClientReader,
     writer: NamedPipeClientWriter,
+    state: Vec<Monitor>,
 }
 
 impl Client {
     pub fn connect() -> eyre::Result<Self> {
-        let (reader, writer) = win_pipes::NamedPipeClientOptions::new("virtualdisplaydriver")
-            .wait()
-            .access_duplex()
-            .mode_message()
-            .create()?;
+        let (mut reader, mut writer) =
+            win_pipes::NamedPipeClientOptions::new("virtualdisplaydriver")
+                .wait()
+                .access_duplex()
+                .mode_message()
+                .create()?;
 
-        Ok(Self { reader, writer })
+        send_command(&mut writer, &driver_ipc::Command::RequestState)?;
+        let state = receive_command(&mut reader)?;
+        let driver_ipc::Command::ReplyState(state) = state else {
+            eyre::bail!("received unexpected reply from driver pipe");
+        };
+
+        Ok(Self { writer, state })
     }
 
-    pub fn list(&mut self) -> eyre::Result<Vec<Monitor>> {
-        self.send_command(&driver_ipc::Command::RequestState)?;
-        let response = self.receive_command()?;
-
-        match response {
-            driver_ipc::Command::ReplyState(state) => Ok(state),
-            _ => eyre::bail!("received unexpected reply from driver pipe"),
-        }
+    pub fn monitors(&self) -> &[Monitor] {
+        &self.state
     }
 
     pub fn get(&mut self, id: driver_ipc::Id) -> eyre::Result<Monitor> {
-        let monitors = self.list()?;
-        let monitor = monitors.into_iter().find(|monitor| monitor.id == id);
+        let monitor = self.state.iter().find(|monitor| monitor.id == id);
 
         match monitor {
-            Some(monitor) => Ok(monitor),
+            Some(monitor) => Ok(monitor.clone()),
             None => eyre::bail!("no virtual monitor with ID {} found", id),
         }
     }
@@ -43,7 +43,7 @@ impl Client {
     pub fn notify(&mut self, monitors: Vec<driver_ipc::Monitor>) -> eyre::Result<()> {
         let command = driver_ipc::Command::DriverNotify(monitors);
 
-        self.send_command(&command)?;
+        send_command(&mut self.writer, &command)?;
 
         Ok(())
     }
@@ -51,7 +51,7 @@ impl Client {
     pub fn remove(&mut self, ids: Vec<driver_ipc::Id>) -> eyre::Result<()> {
         let command = driver_ipc::Command::DriverRemove(ids);
 
-        self.send_command(&command)?;
+        send_command(&mut self.writer, &command)?;
 
         Ok(())
     }
@@ -59,22 +59,20 @@ impl Client {
     pub fn remove_all(&mut self) -> eyre::Result<()> {
         let command = driver_ipc::Command::DriverRemoveAll;
 
-        self.send_command(&command)?;
+        send_command(&mut self.writer, &command)?;
 
         Ok(())
     }
 
     pub fn new_id(&mut self, preferred_id: Option<driver_ipc::Id>) -> eyre::Result<driver_ipc::Id> {
-        let monitors = self.list()?;
-
         if let Some(id) = preferred_id {
-            if monitors.iter().any(|monitor| monitor.id == id) {
+            if self.state.iter().any(|monitor| monitor.id == id) {
                 eyre::bail!("monitor with ID {} already exists", id);
             }
 
             Ok(id)
         } else {
-            let max_id = monitors.iter().map(|monitor| monitor.id).max();
+            let max_id = self.state.iter().map(|monitor| monitor.id).max();
             let id = match max_id {
                 Some(id) => id + 1,
                 None => 0,
@@ -82,29 +80,28 @@ impl Client {
             Ok(id)
         }
     }
+}
 
-    fn send_command(&mut self, command: &driver_ipc::Command) -> eyre::Result<()> {
-        // Create a vector with the full message, then send it as a single
-        // write. This is required because the pipe is in message mode.
-        let message = serde_json::to_vec(command).wrap_err("failed to serialize command")?;
-        self.writer
-            .write_all(&message)
-            .wrap_err("failed to write to driver pipe")?;
-        self.writer
-            .flush()
-            .wrap_err("failed to flush driver pipe")?;
+fn send_command(
+    ipc_writer: &mut NamedPipeClientWriter,
+    command: &driver_ipc::Command,
+) -> eyre::Result<()> {
+    // Create a vector with the full message, then send it as a single
+    // write. This is required because the pipe is in message mode.
+    let message = serde_json::to_vec(command).wrap_err("failed to serialize command")?;
+    ipc_writer
+        .write_all(&message)
+        .wrap_err("failed to write to driver pipe")?;
+    ipc_writer.flush().wrap_err("failed to flush driver pipe")?;
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    fn receive_command(&mut self) -> eyre::Result<driver_ipc::Command> {
-        let response = self
-            .reader
-            .read_full()
-            .wrap_err("failed to read from driver pipe")?;
-        let command =
-            serde_json::from_slice(&response).wrap_err("failed to deserialize command")?;
+fn receive_command(ipc_reader: &mut NamedPipeClientReader) -> eyre::Result<driver_ipc::Command> {
+    let response = ipc_reader
+        .read_full()
+        .wrap_err("failed to read from driver pipe")?;
+    let command = serde_json::from_slice(&response).wrap_err("failed to deserialize command")?;
 
-        Ok(command)
-    }
+    Ok(command)
 }

--- a/virtual-display-driver-cli/src/main.rs
+++ b/virtual-display-driver-cli/src/main.rs
@@ -360,6 +360,7 @@ fn disable(
 }
 
 fn remove(client: &mut Client, opts: &GlobalOptions, command: &RemoveCommand) -> eyre::Result<()> {
+    client.validate_has_ids(&command.id)?;
     client.remove(command.id.clone())?;
 
     if opts.json {

--- a/virtual-display-driver-cli/src/main.rs
+++ b/virtual-display-driver-cli/src/main.rs
@@ -149,7 +149,7 @@ fn main() -> eyre::Result<()> {
 }
 
 fn list(client: &mut Client, opts: &GlobalOptions) -> eyre::Result<()> {
-    let monitors = client.list()?;
+    let monitors = client.monitors();
 
     if opts.json {
         let mut stdout = std::io::stdout().lock();


### PR DESCRIPTION
This PR updates the `Client::connect()` function to both improve the error message, and to additionally grab the starting list of monitors and cache it in the `Client` struct. With those changes and a few cascading changes that resulted, I was able to knock out a few tasks from #48, namely these items:

- Easy to read error message if client doesn't connect
- Make `RequestState` more global
- Use smallest available IDs
- Make client connection global / always store requested state so it can be accessible anywhere.
- With global state, other checks can be made smarter, such as displaying an error when user tries to remove a monitor ID that doesn't exist.