### PR TITLE
Clean up CLI for adding/removing modes and monitors

### DIFF
--- a/rust/virtual-display-driver-cli/src/client.rs
+++ b/rust/virtual-display-driver-cli/src/client.rs
@@ -32,6 +32,7 @@ impl Client {
         &self.state
     }
 
+    /// Find a monitor by ID or name.
     pub fn find_monitor(&self, query: &str) -> eyre::Result<Monitor> {
         let query_id: Option<driver_ipc::Id> = query.parse().ok();
         if let Some(query_id) = query_id {

--- a/rust/virtual-display-driver-cli/src/client.rs
+++ b/rust/virtual-display-driver-cli/src/client.rs
@@ -1,11 +1,7 @@
-use std::{
-    collections::{BTreeSet, HashSet},
-    io::Write as _,
-};
+use std::{collections::HashSet, io::Write as _};
 
 use driver_ipc::Monitor;
 use eyre::Context as _;
-use joinery::Joinable as _;
 use win_pipes::{NamedPipeClientReader, NamedPipeClientWriter};
 
 pub struct Client {
@@ -36,13 +32,24 @@ impl Client {
         &self.state
     }
 
-    pub fn get(&mut self, id: driver_ipc::Id) -> eyre::Result<Monitor> {
-        let monitor = self.state.iter().find(|monitor| monitor.id == id);
-
-        match monitor {
-            Some(monitor) => Ok(monitor.clone()),
-            None => eyre::bail!("virtual monitor with ID {} not found", id),
+    pub fn find_monitor(&self, query: &str) -> eyre::Result<Monitor> {
+        let query_id: Option<driver_ipc::Id> = query.parse().ok();
+        if let Some(query_id) = query_id {
+            let monitor_by_id = self.state.iter().find(|monitor| monitor.id == query_id);
+            if let Some(monitor) = monitor_by_id {
+                return Ok(monitor.clone());
+            }
         }
+
+        let monitor_by_name = self
+            .state
+            .iter()
+            .find(|monitor| monitor.name.as_deref().is_some_and(|name| name == query));
+        if let Some(monitor) = monitor_by_name {
+            return Ok(monitor.clone());
+        }
+
+        eyre::bail!("virtual monitor with ID {} not found", query);
     }
 
     pub fn notify(&mut self, monitors: Vec<driver_ipc::Monitor>) -> eyre::Result<()> {
@@ -51,27 +58,6 @@ impl Client {
         send_command(&mut self.writer, &command)?;
 
         Ok(())
-    }
-
-    pub fn validate_has_ids(&self, ids: &[driver_ipc::Id]) -> eyre::Result<()> {
-        let ids = ids.iter().copied().collect::<BTreeSet<_>>();
-        let existing_ids = self
-            .state
-            .iter()
-            .map(|monitor| monitor.id)
-            .collect::<BTreeSet<_>>();
-        let missing_ids = ids.difference(&existing_ids).copied().collect::<Vec<_>>();
-
-        if missing_ids.is_empty() {
-            Ok(())
-        } else if missing_ids.len() == 1 {
-            eyre::bail!("virtual monitor with ID {} not found", missing_ids[0])
-        } else {
-            eyre::bail!(
-                "virtual monitors with IDs not found: {}",
-                missing_ids.join_with(", ")
-            )
-        }
     }
 
     pub fn remove(&mut self, ids: Vec<driver_ipc::Id>) -> eyre::Result<()> {

--- a/rust/virtual-display-driver-cli/src/main.rs
+++ b/rust/virtual-display-driver-cli/src/main.rs
@@ -164,23 +164,20 @@ fn list(client: &mut Client, opts: &GlobalOptions) -> eyre::Result<()> {
             if monitor.modes.is_empty() {
                 println!("{} {}", "-".dimmed(), "No modes".red());
             } else {
-                for (index, mode) in monitor.modes.iter().enumerate() {
+                for mode in &monitor.modes {
                     let refresh_rate_labels = mode
                         .refresh_rates
                         .iter()
                         .map(|rate| lazy_format!("{}", rate.blue()))
                         .join_with("/");
-                    let refresh_rates = lazy_format!(if mode.refresh_rates.is_empty() =>
-                        ("{}Hz", "?".red())
-                    else =>
-                        ("{}Hz", refresh_rate_labels)
-                    );
                     println!(
-                        "{} Mode {index}: {}x{} @ {}",
+                        "{} {}{}{}{}{}",
                         "-".dimmed(),
                         mode.width.green(),
+                        "x".dimmed(),
                         mode.height.green(),
-                        refresh_rates
+                        "@".dimmed(),
+                        refresh_rate_labels,
                     );
                 }
             }

--- a/rust/virtual-display-driver-cli/src/main.rs
+++ b/rust/virtual-display-driver-cli/src/main.rs
@@ -238,7 +238,7 @@ fn add_mode(
         new_modes.into_iter().map(driver_ipc::Mode::from).collect();
 
     monitor.modes = new_modes.clone();
-    client.notify(vec![monitor])?;
+    client.notify(vec![monitor.clone()])?;
 
     if opts.json {
         let mut stdout = std::io::stdout().lock();
@@ -246,7 +246,7 @@ fn add_mode(
     } else {
         println!(
             "Added modes to virtual monitor with ID {}.",
-            command.id.green()
+            monitor.id.green()
         );
     }
 
@@ -266,7 +266,7 @@ fn remove_mode(
         new_modes.into_iter().map(driver_ipc::Mode::from).collect();
 
     monitor.modes = new_modes.clone();
-    client.notify(vec![monitor])?;
+    client.notify(vec![monitor.clone()])?;
 
     if opts.json {
         let mut stdout = std::io::stdout().lock();
@@ -275,7 +275,7 @@ fn remove_mode(
         println!(
             "Removed mode {} from virtual monitor with ID {}.",
             command.mode.blue(),
-            command.id.green()
+            monitor.id.green()
         );
     }
 
@@ -296,7 +296,7 @@ fn enable(client: &mut Client, opts: &GlobalOptions, command: &EnableCommand) ->
         };
         println!(
             "Enabled virtual monitor with ID {}{footnote}.",
-            command.id.green()
+            outcome.monitor.id.green()
         );
     }
 
@@ -321,7 +321,7 @@ fn disable(
         };
         println!(
             "Disabled virtual monitor with ID {}{footnote}.",
-            command.id.green()
+            outcome.monitor.id.green()
         );
     }
 

--- a/rust/virtual-display-driver-cli/src/mode.rs
+++ b/rust/virtual-display-driver-cli/src/mode.rs
@@ -1,0 +1,154 @@
+use std::collections::{BTreeSet, HashMap};
+
+use eyre::Context as _;
+use joinery::JoinableIterator as _;
+
+const DEFAULT_REFRESH_RATE: driver_ipc::RefreshRate = 60;
+
+#[derive(Debug, Clone)]
+pub struct Mode {
+    pub width: driver_ipc::Dimen,
+    pub height: driver_ipc::Dimen,
+    pub refresh_rates: BTreeSet<driver_ipc::RefreshRate>,
+}
+
+impl From<driver_ipc::Mode> for Mode {
+    fn from(value: driver_ipc::Mode) -> Self {
+        Self {
+            width: value.width,
+            height: value.height,
+            refresh_rates: value.refresh_rates.into_iter().collect(),
+        }
+    }
+}
+
+impl From<Mode> for driver_ipc::Mode {
+    fn from(mut value: Mode) -> Self {
+        if value.refresh_rates.is_empty() {
+            value.refresh_rates.insert(DEFAULT_REFRESH_RATE);
+        }
+
+        Self {
+            width: value.width,
+            height: value.height,
+            refresh_rates: value.refresh_rates.into_iter().collect(),
+        }
+    }
+}
+
+impl std::fmt::Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.refresh_rates.is_empty() {
+            write!(f, "{}x{}", self.width, self.height)?;
+        } else {
+            write!(
+                f,
+                "{}x{}@{}",
+                self.width,
+                self.height,
+                self.refresh_rates.iter().join_with("/"),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for Mode {
+    type Err = eyre::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (resolution, refresh_rate_list) = match s.split_once('@') {
+            Some((resolution, refresh_rate_list)) => (resolution, Some(refresh_rate_list)),
+            None => (s, None),
+        };
+
+        let (width, height) = resolution.split_once('x').ok_or_else(|| {
+            eyre::eyre!("invalid resolution in {s:?}, expected a string like \"1920x1080\"",)
+        })?;
+        let width = width
+            .parse()
+            .with_context(|| format!("invalid width in {s:?}, expected a number"))?;
+        let height = height
+            .parse()
+            .with_context(|| format!("invalid height in {s:?}, expected a number"))?;
+
+        let refresh_rates = match refresh_rate_list {
+            Some(refresh_rate_list) => refresh_rate_list
+                .split('/')
+                .map(|s| {
+                    s.parse().with_context(|| {
+                        format!("failed to parse refresh rate in {s:?}, expected a number")
+                    })
+                })
+                .collect::<eyre::Result<_>>()?,
+            None => BTreeSet::new(),
+        };
+
+        Ok(Self {
+            width,
+            height,
+            refresh_rates,
+        })
+    }
+}
+
+pub fn merge(modes: impl IntoIterator<Item = Mode>) -> Vec<Mode> {
+    let mut resolutions =
+        HashMap::<(driver_ipc::Dimen, driver_ipc::Dimen), BTreeSet<driver_ipc::RefreshRate>>::new();
+
+    for mode in modes {
+        let refresh_rates = resolutions.entry((mode.width, mode.height)).or_default();
+        refresh_rates.extend(&mode.refresh_rates);
+    }
+
+    resolutions
+        .into_iter()
+        .map(|((width, height), refresh_rates)| Mode {
+            width,
+            height,
+            refresh_rates,
+        })
+        .collect()
+}
+
+pub fn remove(
+    modes: impl IntoIterator<Item = Mode>,
+    remove_mode: &Mode,
+) -> eyre::Result<Vec<Mode>> {
+    let mut resolutions =
+        HashMap::<(driver_ipc::Dimen, driver_ipc::Dimen), BTreeSet<driver_ipc::RefreshRate>>::new();
+
+    for mode in modes {
+        let refresh_rates = resolutions.entry((mode.width, mode.height)).or_default();
+        refresh_rates.extend(&mode.refresh_rates);
+    }
+
+    if remove_mode.refresh_rates.is_empty() {
+        let removed = resolutions.remove(&(remove_mode.width, remove_mode.height));
+        if removed.is_none() {
+            eyre::bail!("mode {remove_mode} not found");
+        }
+    } else {
+        let Some(refresh_rates) = resolutions.get_mut(&(remove_mode.width, remove_mode.height))
+        else {
+            eyre::bail!("mode {remove_mode} not found");
+        };
+        for refresh_rate in &remove_mode.refresh_rates {
+            let removed = refresh_rates.remove(refresh_rate);
+            if !removed {
+                eyre::bail!("mode {remove_mode} not found");
+            }
+        }
+    }
+
+    let modes = resolutions
+        .into_iter()
+        .map(|((width, height), refresh_rates)| Mode {
+            width,
+            height,
+            refresh_rates,
+        })
+        .collect();
+    Ok(modes)
+}


### PR DESCRIPTION
This PR should close out the final pieces from https://github.com/MolotovCherry/virtual-display-rs/issues/48, namely these bullet points:

> - For add/add-mode/remove-mode, allow specifying custom refresh rates per monitor mode. Making it clearer to type is also a bonus. - [comment](https://github.com/MolotovCherry/virtual-display-rs/pull/47/files#r1414539525)
> - Deprecate mode indexes and allow selection of monitors by unique WIDTH/HEIGHT. Potentially also allow deleting only refresh rate instead of entire mode. - [comment](https://github.com/MolotovCherry/virtual-display-rs/pull/47/files#r1414544039). UX TBD

Basically, adding a monitor or mode now uses a compact string, so these are all valid commands:

- `add 1920x1080@60/90 3840x2160`
  - Add a monitor with 3 modes: 1920x1080@60, 1920x1080@90, 3840x2160@60
- `add-mode 0 1920x1080@60/90 3840x2160`
  - Add 3 modes to an existing monitor: 1920x1080@60, 1920x1080@90, 3840x2160@60

Removing modes uses the same string format, but there's one small difference: if you leave off the refresh rate, it removes all modes (not just `@60`)

- `remove-mode 0 1920x1080@60`
  - Remove just 1920x1080@60 from an existing monitor
- `remove-mode 0 1920x1080`
  - Remove 1920x1080 completely from an existing monitor (all refresh rates)

I also tweaked `add-mode`, `remove`, and `remove-mode` to support using a monitor's name instead of its ID. So, this series of commands should work:

```
virtual-display-driver-cli.exe add --name foo 3840x2160
virtual-display-driver-cli.exe add-mode foo 1920x1080@60/90 
virtual-display-driver-cli.exe remove-mode foo 1920x1080
virtual-display-driver-cli.exe remove foo
```

(Also, I really should've opened this PR earlier... I originally wrote all this code in December but forgot to submit it, sorry!)