### PR TITLE
Replace `env_logger` dependency with `env_filter`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 name = "driver-logger"
 version = "0.1.0"
 dependencies = [
- "env_logger",
+ "env_filter",
  "log",
  "thiserror",
  "widestring",
@@ -303,16 +303,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
-dependencies = [
- "env_filter",
  "log",
 ]
 

--- a/rust/driver-logger/Cargo.toml
+++ b/rust/driver-logger/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 log = { version = "0.4.21", features = ["std"] }
-env_logger = { version = "0.11.2", default-features = false, optional = true }
+env_filter = { version = "0.1.0", default-features = false, optional = true }
 widestring = "1.0.2"
 winreg = "0.52.0"
 thiserror = "1.0.57"

--- a/rust/driver-logger/src/win_logger.rs
+++ b/rust/driver-logger/src/win_logger.rs
@@ -40,9 +40,9 @@ pub enum Error {
     SetLoggerFailed(#[from] SetLoggerError),
 }
 
-#[cfg(not(feature = "env_logger"))]
+#[cfg(not(feature = "env_filter"))]
 struct Filter {}
-#[cfg(not(feature = "env_logger"))]
+#[cfg(not(feature = "env_filter"))]
 impl Filter {
     fn enabled(&self, _metadata: &Metadata) -> bool {
         true
@@ -51,17 +51,16 @@ impl Filter {
         true
     }
 }
-#[cfg(not(feature = "env_logger"))]
+#[cfg(not(feature = "env_filter"))]
 fn make_filter() -> Filter {
     Filter {}
 }
 
-#[cfg(feature = "env_logger")]
-use env_logger::filter::Filter;
-#[cfg(feature = "env_logger")]
+#[cfg(feature = "env_filter")]
+use env_filter::Filter;
+#[cfg(feature = "env_filter")]
 fn make_filter() -> Filter {
-    use env_logger::filter::Builder;
-    let mut builder = Builder::from_env("RUST_LOG");
+    let mut builder = env_filter::Builder::from_env("RUST_LOG");
     builder.build()
 }
 


### PR DESCRIPTION
I noticed in VS Code that I was getting errors on the `master` branch around the `env_logger` feature (I believe I have my Rust Analyzer is configured to check all features by default).

I did some digging and it looks like the build has been broken when the `env_logger` feature is enabled for a while. I believe it started in #75, which updated `env_logger` from 0.10.1 to 0.11.0. The [release notes for `env_logger`](https://github.com/rust-cli/env_logger/blob/98ce8038803d048bf415a5ab13f7cc1aa61d242e/CHANGELOG.md#0110---2024-01-19) noted that the `filter` module was removed, in favor of the new `env_filter` crate. It looks like the CI/CD pipeline doesn't test the `env_logger` feature, so this breakage went unnoticed.

I updated the Rust code to use `env_filter` in place of `env_logger`. This also means the feature is now called `env_filter` (e.g. `cargo check --features env_filter`).