### PR TITLE
Refactor IPC API implementation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "windows",
  "winreg",
 ]
@@ -346,6 +347,18 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "gimli"
@@ -869,15 +882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,9 +994,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -1007,6 +1009,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/driver-ipc/Cargo.toml
+++ b/rust/driver-ipc/Cargo.toml
@@ -13,4 +13,10 @@ windows = { version = "0.54.0", features = ["Win32_Foundation"] }
 lazy_format = "2.0.3"
 joinery = "3.1.0"
 winreg = "0.52.0"
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.37.0", features = [
+    "rt-multi-thread",
+    "sync",
+    "time",
+    "net",
+] }
+tokio-stream = { version = "0.1.15", features = ["sync"] }

--- a/rust/driver-ipc/Cargo.toml
+++ b/rust/driver-ipc/Cargo.toml
@@ -18,5 +18,16 @@ tokio = { version = "1.37.0", features = [
     "sync",
     "time",
     "net",
+    "macros",
 ] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1.37.0", features = [
+    "rt-multi-thread",
+    "sync",
+    "time",
+    "net",
+    "macros",
+    "io-util",
+] }

--- a/rust/driver-ipc/src/client.rs
+++ b/rust/driver-ipc/src/client.rs
@@ -40,14 +40,18 @@ impl Client {
     /// Connect to driver on pipe with default name.
     ///
     /// The default name is [DEFAULT_PIPE_NAME].
-    pub fn connect() -> Result<Self, error::ConnectionError> {
-        Self::connect_to(DEFAULT_PIPE_NAME)
+    ///
+    /// This method is async because it requires a running tokio reactor.
+    pub async fn connect() -> Result<Self, error::ConnectionError> {
+        Self::connect_to(DEFAULT_PIPE_NAME).await
     }
 
     /// Connect to driver on pipe with specified name.
     ///
     /// `name` is ONLY the {name} portion of \\.\pipe\{name}.
-    pub fn connect_to(name: &str) -> Result<Self, error::ConnectionError> {
+    ///
+    /// This method is async because it requires a running tokio reactor.
+    pub async fn connect_to(name: &str) -> Result<Self, error::ConnectionError> {
         let client = named_pipe::ClientOptions::new()
             .read(true)
             .write(true)
@@ -401,7 +405,9 @@ mod test {
 
         let mut server = MockServer::new(PIPE_NAME);
 
-        let client1 = Client::connect_to(PIPE_NAME).expect("Failed to connect to pipe");
+        let client1 = Client::connect_to(PIPE_NAME)
+            .await
+            .expect("Failed to connect to pipe");
         let stream1 = client1.receive_events();
 
         let client2 = client1.clone();
@@ -434,7 +440,9 @@ mod test {
 
         let server = MockServer::new(PIPE_NAME);
 
-        let client = Client::connect_to(PIPE_NAME).expect("Failed to connect to pipe");
+        let client = Client::connect_to(PIPE_NAME)
+            .await
+            .expect("Failed to connect to pipe");
 
         let stream = client.receive_events();
 
@@ -457,7 +465,9 @@ mod test {
 
         let mut server = MockServer::new(PIPE_NAME);
 
-        let client = Client::connect_to(PIPE_NAME).expect("Failed to connect to pipe");
+        let client = Client::connect_to(PIPE_NAME)
+            .await
+            .expect("Failed to connect to pipe");
 
         // Get receiver stream
 

--- a/rust/driver-ipc/src/client.rs
+++ b/rust/driver-ipc/src/client.rs
@@ -156,7 +156,6 @@ impl Client {
 impl Drop for Client {
     fn drop(&mut self) {
         if Arc::strong_count(&self.notify) == 2 {
-            println!("No receivers, stopping receiver task");
             self.notify.notify_waiters();
         }
     }

--- a/rust/driver-ipc/src/client.rs
+++ b/rust/driver-ipc/src/client.rs
@@ -179,7 +179,7 @@ impl Client {
         let mut reg_key = hklm.open_subkey_with_flags(key, enums::KEY_WRITE);
 
         // if open failed, try to create key and subkey
-        if let Err(_) = reg_key {
+        if reg_key.is_err() {
             reg_key = hklm.create_subkey(key).map(|(key, _)| key);
 
             if let Err(e) = reg_key {

--- a/rust/driver-ipc/src/client.rs
+++ b/rust/driver-ipc/src/client.rs
@@ -219,8 +219,8 @@ async fn receive_command(
     loop {
         // wait for client to be readable
         tokio::select! {
-            _ = client.readable() => {}
-            _ = notify.notified() => return Ok(())
+            r = client.readable() => r?,
+            _ = notify.notified() => return Ok(()),
         }
 
         match client.try_read(&mut buf) {

--- a/rust/driver-ipc/src/client.rs
+++ b/rust/driver-ipc/src/client.rs
@@ -11,7 +11,6 @@ use tokio::{
 use tokio_stream::{Stream, StreamExt};
 
 use crate::*;
-use std::result::Result;
 
 // EOF byte used to separate messages
 pub(crate) const EOF: u8 = 0x4;

--- a/rust/driver-ipc/src/client.rs
+++ b/rust/driver-ipc/src/client.rs
@@ -297,6 +297,8 @@ mod test {
 
         let stream = client.receive_events();
 
+        sleep(Duration::from_millis(50)).await;
+
         drop(server);
 
         let events: Vec<_> = stream.collect().await;

--- a/rust/driver-ipc/src/driver_client.rs
+++ b/rust/driver-ipc/src/driver_client.rs
@@ -32,7 +32,7 @@ impl DriverClient {
     ///
     /// `name` is ONLY the {name} portion of \\.\pipe\{name}.
     pub async fn new_with(name: &str) -> Result<Self, error::InitError> {
-        let client = Client::connect_to(name)?;
+        let client = Client::connect_to(name).await?;
 
         let current_state = client.request_state().await?;
 

--- a/rust/driver-ipc/src/driver_client.rs
+++ b/rust/driver-ipc/src/driver_client.rs
@@ -350,7 +350,7 @@ impl DriverClient {
     /// manually call [DriverClient::refresh_state].
     pub fn add(&mut self, monitor: Monitor) -> Result<(), error::DuplicateError> {
         if self.state.iter().any(|mon| mon.id == monitor.id) {
-            return Err(error::DuplicateError::DupMonitor(monitor.id));
+            return Err(error::DuplicateError::Monitor(monitor.id));
         }
         mon_has_duplicates(&monitor)?;
 
@@ -423,7 +423,7 @@ impl DriverClient {
 
         match mode_has_duplicates(&mode, id) {
             Ok(_) => Ok(()),
-            Err(error::DuplicateError::DupRefreshRate(rr, w, h, id)) => {
+            Err(error::DuplicateError::RefreshRate(rr, w, h, id)) => {
                 Err(error::AddModeError::DupRefreshRate(rr, w, h, id))
             }
             Err(_) => unreachable!(),
@@ -562,7 +562,7 @@ fn mons_have_duplicates(monitors: &[Monitor]) -> Result<(), error::DuplicateErro
     while let Some(monitor) = monitor_iter.next() {
         let duplicate_id = monitor_iter.clone().any(|b| monitor.id == b.id);
         if duplicate_id {
-            return Err(error::DuplicateError::DupMonitor(monitor.id));
+            return Err(error::DuplicateError::Monitor(monitor.id));
         }
 
         mon_has_duplicates(monitor)?;
@@ -578,7 +578,7 @@ fn mon_has_duplicates(monitor: &Monitor) -> Result<(), error::DuplicateError> {
             .clone()
             .any(|m| mode.height == m.height && mode.width == m.width);
         if duplicate_mode {
-            return Err(error::DuplicateError::DupMode(
+            return Err(error::DuplicateError::Mode(
                 mode.width,
                 mode.height,
                 monitor.id,
@@ -596,7 +596,7 @@ fn mode_has_duplicates(mode: &Mode, id: Id) -> Result<(), error::DuplicateError>
     while let Some(rr) = refresh_iter.next() {
         let duplicate_rr = refresh_iter.clone().any(|r| rr == r);
         if duplicate_rr {
-            return Err(error::DuplicateError::DupRefreshRate(
+            return Err(error::DuplicateError::RefreshRate(
                 rr,
                 mode.width,
                 mode.height,
@@ -616,11 +616,11 @@ pub mod error {
     #[derive(Debug, Error)]
     pub enum DuplicateError {
         #[error("Duplicate monitor with ID {0}")]
-        DupMonitor(Id),
+        Monitor(Id),
         #[error("Duplicate mode {1}x{2} on monitor {0}")]
-        DupMode(u32, u32, Id),
+        Mode(u32, u32, Id),
         #[error("Duplicate refresh rate {0} on mode {1}x{2} on monitor {3}")]
-        DupRefreshRate(u32, u32, u32, Id),
+        RefreshRate(u32, u32, u32, Id),
     }
 
     #[derive(Debug, Error)]
@@ -631,6 +631,7 @@ pub mod error {
     #[error("Monitor not found: {0}")]
     pub struct MonNotFound(pub Id);
 
+    /// Error returned from [DriverClient::add_mode].
     #[derive(Debug, Error)]
     pub enum AddModeError {
         #[error("Monitor not found: {0}")]
@@ -641,6 +642,7 @@ pub mod error {
         DupRefreshRate(u32, u32, u32, Id),
     }
 
+    /// Error returned from [DriverClient::add_mode_query].
     #[derive(Debug, Error)]
     pub enum AddModeQueryError {
         #[error("Query not found: {0}")]
@@ -651,6 +653,7 @@ pub mod error {
         DupRefreshRate(u32, u32, u32, Id),
     }
 
+    /// Error returned from [DriverClient::new] and [DriverClient::new_with].
     #[derive(Debug, Error)]
     pub enum InitError {
         #[error("Failed to connect to driver: {0}")]

--- a/rust/driver-ipc/src/driver_client.rs
+++ b/rust/driver-ipc/src/driver_client.rs
@@ -43,12 +43,10 @@ impl DriverClient {
 
         task::spawn(async move {
             while let Some(event) = stream.next().await {
-                match event {
-                    EventCommand::Changed(value) => {
-                        if state_tx.send(value).is_err() {
-                            // Client was dropped, stop listening
-                            break;
-                        }
+                if let Ok(EventCommand::Changed(value)) = event {
+                    if state_tx.send(value).is_err() {
+                        // Client was dropped, stop listening
+                        break;
                     }
                 }
             }
@@ -118,7 +116,7 @@ impl DriverClient {
     /// Note: If multiple copies of this client exist (using
     /// [DriverClient::duplicate]), the returned stream will only be closed
     /// after all copies are dropped.
-    pub fn receive_events(&self) -> impl Stream<Item = EventCommand> {
+    pub fn receive_events(&self) -> impl Stream<Item = Result<EventCommand, error::ReceiveError>> {
         self.client.receive_events()
     }
 

--- a/rust/driver-ipc/src/driver_client.rs
+++ b/rust/driver-ipc/src/driver_client.rs
@@ -4,7 +4,6 @@ use tokio::{sync::watch, task};
 use tokio_stream::{Stream, StreamExt};
 
 use crate::*;
-use std::result::Result;
 
 /// Abstraction layer over [Client].
 ///

--- a/rust/driver-ipc/src/lib.rs
+++ b/rust/driver-ipc/src/lib.rs
@@ -8,6 +8,8 @@ pub use client::Client;
 pub use core::*;
 pub use driver_client::DriverClient;
 
+pub static DEFAULT_PIPE_NAME: &str = "virtualdisplaydriver";
+
 pub type Result<T> = std::result::Result<T, IpcError>;
 
 #[derive(Debug, thiserror::Error)]
@@ -16,12 +18,10 @@ pub enum IpcError {
     SerDe(#[from] serde_json::Error),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("windows api error: {0}")]
-    Win(#[from] windows::core::Error),
     #[error("{0}")]
     Client(#[from] ClientError),
-    #[error("failed to get request state")]
-    RequestState,
+    #[error("did not get a response in time")]
+    Timeout,
     #[error("failed to receive command")]
     Receive,
     #[error("failed to open pipe. is driver installed and working?\nerror: {0}")]
@@ -36,10 +36,6 @@ pub enum ClientError {
     MonNotFound(Id),
     #[error("monitor query \"{0}\" not found")]
     QueryNotFound(String),
-    #[error("monitor {0} already exists")]
-    MonExists(Id),
-    #[error("mode {0}x{1} already exists")]
-    ModeExists(Dimen, Dimen),
     #[error("detected duplicate refresh rate {0}")]
     RefreshRateExists(RefreshRate),
     #[error("found duplicate monitor id {0}")]

--- a/rust/driver-ipc/src/lib.rs
+++ b/rust/driver-ipc/src/lib.rs
@@ -8,6 +8,9 @@ pub use client::Client;
 pub use core::*;
 pub use driver_client::DriverClient;
 
+#[cfg(test)]
+mod mock;
+
 pub static DEFAULT_PIPE_NAME: &str = "virtualdisplaydriver";
 
 pub type Result<T> = std::result::Result<T, IpcError>;

--- a/rust/driver-ipc/src/lib.rs
+++ b/rust/driver-ipc/src/lib.rs
@@ -12,39 +12,3 @@ pub use driver_client::DriverClient;
 mod mock;
 
 pub static DEFAULT_PIPE_NAME: &str = "virtualdisplaydriver";
-
-pub type Result<T> = std::result::Result<T, IpcError>;
-
-#[derive(Debug, thiserror::Error)]
-pub enum IpcError {
-    #[error("failed to (de)serialize: {0}")]
-    SerDe(#[from] serde_json::Error),
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("{0}")]
-    Client(#[from] ClientError),
-    #[error("did not get a response in time")]
-    Timeout,
-    #[error("failed to receive command")]
-    Receive,
-    #[error("failed to open pipe. is driver installed and working?\nerror: {0}")]
-    ConnectionFailed(std::io::Error),
-    #[error("channel closed")]
-    SendFailed,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ClientError {
-    #[error("monitor id {0} not found")]
-    MonNotFound(Id),
-    #[error("monitor query \"{0}\" not found")]
-    QueryNotFound(String),
-    #[error("detected duplicate refresh rate {0}")]
-    RefreshRateExists(RefreshRate),
-    #[error("found duplicate monitor id {0}")]
-    DupMon(Id),
-    #[error("found duplicate mode {0}x{1} on monitor {2}")]
-    DupMode(Dimen, Dimen, Id),
-    #[error("found duplicate refresh rate {0} on {1}x{2} for monitor {3}")]
-    DupRefreshRate(RefreshRate, Dimen, Dimen, Id),
-}

--- a/rust/driver-ipc/src/mock.rs
+++ b/rust/driver-ipc/src/mock.rs
@@ -1,0 +1,141 @@
+use std::{io, sync::Arc};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::windows::named_pipe,
+    sync::broadcast,
+    task,
+};
+
+use crate::*;
+
+use self::client::EOF;
+
+pub struct MockServer {
+    server: Arc<named_pipe::NamedPipeServer>,
+    state: Vec<Monitor>,
+    command_rx: broadcast::Receiver<ServerCommand>,
+    command_tx: broadcast::Sender<ServerCommand>,
+}
+
+impl MockServer {
+    pub fn new(name: &str) -> Self {
+        let server = named_pipe::ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .reject_remote_clients(true)
+            .create(format!(r"\\.\pipe\{}", name))
+            .unwrap();
+        let server = Arc::new(server);
+
+        let (command_tx, command_rx) = broadcast::channel(64);
+
+        {
+            let server = server.clone();
+            let command_tx = command_tx.clone();
+            task::spawn(async move {
+                let server = unsafe {
+                    (server.as_ref() as *const _ as *mut named_pipe::NamedPipeServer)
+                        .as_mut()
+                        .unwrap()
+                };
+
+                server.connect().await.expect("Failed to connect to server");
+
+                loop {
+                    let mut buf = vec![];
+                    loop {
+                        let v = match server.read_u8().await {
+                            Ok(v) => v,
+                            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return, // Client disconnected
+                            Err(e) => panic!("Failed to read byte: {:?}", e),
+                        };
+                        if v == EOF {
+                            break;
+                        }
+                        buf.push(v);
+                    }
+
+                    let cmd = serde_json::from_slice::<ServerCommand>(&buf)
+                        .expect("Failed to deserialize request");
+
+                    command_tx.send(cmd).expect("Failed to send command");
+                }
+            });
+        }
+
+        Self {
+            server,
+            state: vec![],
+            command_rx,
+            command_tx,
+        }
+    }
+
+    pub fn state(&self) -> &[Monitor] {
+        &self.state
+    }
+
+    pub fn check_next(&mut self, cb: impl FnOnce(ServerCommand) + Send + 'static) {
+        let mut rx = self.command_tx.subscribe();
+
+        task::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(cmd) => {
+                        cb(cmd);
+                        break;
+                    }
+                    Err(_) => continue,
+                }
+            }
+        });
+    }
+
+    pub async fn pump(&mut self) {
+        let cmd = self.command_rx.recv().await.unwrap();
+
+        let server = unsafe {
+            (self.server.as_ref() as *const _ as *mut named_pipe::NamedPipeServer)
+                .as_mut()
+                .unwrap()
+        };
+
+        let changed = match cmd {
+            ServerCommand::Request(RequestCommand::State) => {
+                let reply = ReplyCommand::State(self.state.clone());
+                let mut reply = serde_json::to_vec(&reply).unwrap();
+                reply.push(EOF);
+
+                server
+                    .write_all(&reply)
+                    .await
+                    .expect("Failed to write reply");
+                false
+            }
+            ServerCommand::Driver(DriverCommand::Notify(monitors)) => {
+                self.state = monitors;
+                true
+            }
+            ServerCommand::Driver(DriverCommand::Remove(ids)) => {
+                self.state.retain(|m| !ids.contains(&m.id));
+                true
+            }
+            ServerCommand::Driver(DriverCommand::RemoveAll) => {
+                self.state.clear();
+                true
+            }
+        };
+
+        if changed {
+            let event = EventCommand::Changed(self.state.clone());
+            let mut event = serde_json::to_vec(&event).unwrap();
+            event.push(EOF);
+
+            server
+                .write_all(&event)
+                .await
+                .expect("Failed to write event");
+        }
+    }
+}

--- a/rust/driver-ipc/src/sync.rs
+++ b/rust/driver-ipc/src/sync.rs
@@ -8,5 +8,10 @@ use tokio::runtime::{Builder, Runtime};
 
 use crate::utils::LazyLock;
 
-static RUNTIME: LazyLock<Runtime> =
-    LazyLock::new(|| Builder::new_multi_thread().enable_all().build().unwrap());
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap()
+});

--- a/rust/driver-ipc/src/sync/client.rs
+++ b/rust/driver-ipc/src/sync/client.rs
@@ -1,5 +1,7 @@
+use tokio_stream::StreamExt;
+
 use super::RUNTIME;
-use crate::{Client as AsyncClient, EventCommand, Id, Monitor, ReplyCommand, Result};
+use crate::{Client as AsyncClient, EventCommand, Id, Monitor, Result};
 
 /// A thin api client over the driver api with all the essential api.
 /// Does the bare minimum required. Does not track state
@@ -9,14 +11,14 @@ pub struct Client(AsyncClient);
 impl Client {
     /// connect to pipe virtualdisplaydriver
     pub fn connect() -> Result<Self> {
-        let client = RUNTIME.block_on(AsyncClient::connect())?;
+        let client = AsyncClient::connect()?;
         Ok(Self(client))
     }
 
     // choose which pipe name you connect to
     // pipe name is ONLY the name, only the {name} portion of \\.\pipe\{name}
     pub fn connect_to(name: &str) -> Result<Self> {
-        let client = RUNTIME.block_on(AsyncClient::connect_to(name))?;
+        let client = AsyncClient::connect_to(name)?;
         Ok(Self(client))
     }
 
@@ -35,25 +37,32 @@ impl Client {
         RUNTIME.block_on(self.0.remove_all())
     }
 
-    /// Receive generic reply
-    ///
-    /// If `last` is false, will only receive new messages from the point of calling
-    /// If `last` is true, will receive the the last message received, or if none, blocks until the next one
-    ///
-    /// The reason for the `last` flag is that replies are auto buffered in the background, so if you send a
-    /// request, the reply may be missed
-    pub fn receive_reply(&mut self, last: bool) -> Option<ReplyCommand> {
-        RUNTIME.block_on(self.0.receive_reply(last))
-    }
-
     /// Receive an event. Only new events after calling this are received
     pub fn receive_event(&mut self) -> EventCommand {
-        RUNTIME.block_on(self.0.receive_event())
+        RUNTIME.block_on(async {
+            self.0
+                .receive_events()
+                .next()
+                .await
+                .expect("Stream should never finish")
+        })
+    }
+
+    pub fn add_event_receiver(&mut self, cb: impl Fn(EventCommand) -> bool + Send + 'static) {
+        let mut stream = self.0.receive_events();
+
+        RUNTIME.spawn(async move {
+            while let Some(event) = stream.next().await {
+                if !cb(event) {
+                    break;
+                }
+            }
+        });
     }
 
     /// Request state update
     /// use `receive()` to get the reply
-    pub fn request_state(&self) -> Result<()> {
+    pub fn request_state(&self) -> Result<Vec<Monitor>> {
         RUNTIME.block_on(self.0.request_state())
     }
 

--- a/rust/driver-ipc/src/sync/client.rs
+++ b/rust/driver-ipc/src/sync/client.rs
@@ -49,6 +49,13 @@ impl Client {
         })
     }
 
+    /// Add an event receiver.
+    ///
+    /// Returns an object that can be used to cancel the subscription.
+    ///
+    /// The callback should return as soon as possible. It is called from the
+    /// library's tokio runtime and blocks all other operations. In consequence,
+    /// all other library events will be delayed until the callback returns.
     pub fn add_event_receiver(
         &self,
         cb: impl FnMut(EventCommand) + Send + 'static,

--- a/rust/driver-ipc/src/sync/client.rs
+++ b/rust/driver-ipc/src/sync/client.rs
@@ -25,7 +25,7 @@ impl Client {
     ///
     /// The default name is [crate::DEFAULT_PIPE_NAME].
     pub fn connect() -> Result<Self, error::ConnectionError> {
-        let client = RUNTIME.block_on(async { AsyncClient::connect() })?;
+        let client = RUNTIME.block_on(AsyncClient::connect())?;
         Ok(Self(client))
     }
 
@@ -33,7 +33,7 @@ impl Client {
     ///
     /// `name` is ONLY the {name} portion of \\.\pipe\{name}.
     pub fn connect_to(name: &str) -> Result<Self, error::ConnectionError> {
-        let client = RUNTIME.block_on(async { AsyncClient::connect_to(name) })?;
+        let client = RUNTIME.block_on(AsyncClient::connect_to(name))?;
         Ok(Self(client))
     }
 

--- a/rust/driver-ipc/src/sync/driver_client.rs
+++ b/rust/driver-ipc/src/sync/driver_client.rs
@@ -39,6 +39,13 @@ impl DriverClient {
         self.0.refresh_state()
     }
 
+    /// Add an event receiver.
+    ///
+    /// Returns an object that can be used to cancel the subscription.
+    ///
+    /// The callback should return as soon as possible. It is called from the
+    /// library's tokio runtime and blocks all other operations. In consequence,
+    /// all other library events will be delayed until the callback returns.
     pub fn add_event_receiver(
         &self,
         cb: impl FnMut(EventCommand) + Send + 'static,

--- a/rust/driver-ipc/src/sync/driver_client.rs
+++ b/rust/driver-ipc/src/sync/driver_client.rs
@@ -77,7 +77,7 @@ impl DriverClient {
     /// after all copies are dropped.
     pub fn add_event_receiver(
         &self,
-        cb: impl FnMut(EventCommand) + Send + 'static,
+        cb: impl FnMut(EventCommand) + Send + std::panic::UnwindSafe + 'static,
     ) -> EventsSubscription {
         let stream = self.0.receive_events();
         EventsSubscription::start_subscriber(cb, stream)

--- a/rust/driver-ipc/src/sync/driver_client.rs
+++ b/rust/driver-ipc/src/sync/driver_client.rs
@@ -79,7 +79,10 @@ impl DriverClient {
     /// after all copies are dropped.
     pub fn add_event_receiver(
         &self,
-        cb: impl FnMut(EventCommand) + Send + std::panic::UnwindSafe + 'static,
+        cb: impl FnMut(Result<EventCommand, error::ReceiveError>)
+            + Send
+            + std::panic::UnwindSafe
+            + 'static,
     ) -> EventsSubscription {
         let stream = self.0.receive_events();
         EventsSubscription::start_subscriber(cb, stream)


### PR DESCRIPTION
This is my go on the IPC API.

The driver events are now expressed by a [`Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html). This also allowes for multiple listeners.

Using the sync API, one can now add many receiver callbacks. The termination is now expressed using a boolean return value. 

```rust
driver.add_event_receiver(|cmd| {
  ...
  if finished {
    false
  } else { 
    true 
  };
});
```

Maybe a subscription object is better?

```rust
let subscription = driver.add_event_receiver(|cmd| { ... });
...
subscription.cancel();
```

(Changes are not fully tested)