### PR TITLE
fix: tolerate PnP disable+enable cycles inside one WUDFHost process

### DIFF
--- a/virtual-display-driver/src/callbacks.rs
+++ b/virtual-display-driver/src/callbacks.rs
@@ -39,10 +39,12 @@ pub extern "C-unwind" fn adapter_init_finished(
         return status;
     }
 
-    // store adapter object for listener to use
-    ADAPTER
-        .set(AdapterObject(NonNull::new(adapter_object).unwrap()))
-        .unwrap();
+    // store adapter object for listener to use. Replace any previous
+    // value — PnP re-init inside the same WUDFHost process gives us a
+    // fresh adapter pointer, and the old one is invalid after the
+    // previous disable.
+    *ADAPTER.lock().unwrap() =
+        Some(AdapterObject(NonNull::new(adapter_object).unwrap()));
 
     NTSTATUS::STATUS_SUCCESS
 }

--- a/virtual-display-driver/src/monitor_listener.rs
+++ b/virtual-display-driver/src/monitor_listener.rs
@@ -1,7 +1,10 @@
 use std::{
     ops::ControlFlow,
     ptr::NonNull,
-    sync::{Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex,
+    },
     thread,
 };
 
@@ -17,8 +20,16 @@ use winreg::{
 
 use crate::context::DeviceContext;
 
-pub static ADAPTER: OnceLock<AdapterObject> = OnceLock::new();
-pub static MONITOR_MODES: OnceLock<Mutex<Vec<MonitorObject>>> = OnceLock::new();
+// Statics are `Mutex<Option<T>>` / `Mutex<Vec<T>>` rather than
+// `OnceLock<T>` so the driver tolerates PnP disable+enable cycles
+// inside one WUDFHost process. The UMDF host stays alive across
+// device toggles, so `OnceLock::set(...).unwrap()` panics on the
+// second adapter_init_finished. The listener thread itself is only
+// spawned once per process; subsequent inits just clear+repopulate
+// monitor state from registry.
+pub static ADAPTER: Mutex<Option<AdapterObject>> = Mutex::new(None);
+pub static MONITOR_MODES: Mutex<Vec<MonitorObject>> = Mutex::new(Vec::new());
+static LISTENER_SPAWNED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug)]
 pub struct AdapterObject(pub NonNull<IDDCX_ADAPTER__>);
@@ -35,20 +46,33 @@ unsafe impl Send for MonitorObject {}
 
 /// WARNING: Locks MONITOR_MODES, don't call if already locked or deadlock happens
 pub fn monitor_count() -> usize {
-    MONITOR_MODES.get().unwrap().lock().unwrap().len()
+    MONITOR_MODES.lock().unwrap().len()
 }
 
 pub fn startup() {
-    MONITOR_MODES.set(Mutex::new(Vec::new())).unwrap();
+    // PnP re-init in the same process: drop any stale monitor state
+    // from the previous adapter so the registry-driven config can
+    // repopulate cleanly. Without this the `add()` "id already
+    // present" guard rejects every monitor on the second init.
+    MONITOR_MODES.lock().unwrap().clear();
+
+    // Registry-driven default monitor config. Runs on every init,
+    // not just the first — that's the point: a freshly-written
+    // `data` value picked up via disable+enable cycle materializes
+    // the new monitor on enable.
+    let monitors = get_data();
+    if !monitors.is_empty() {
+        add(monitors);
+    }
+
+    // Pipe listener is per-process, not per-adapter-init. After
+    // the first startup() the thread keeps running and the pipe
+    // stays bound — subsequent inits share it.
+    if LISTENER_SPAWNED.swap(true, Ordering::SeqCst) {
+        return;
+    }
 
     thread::spawn(move || {
-        let monitors = get_data();
-
-        // add default monitors saved in registry
-        if !monitors.is_empty() {
-            add(monitors);
-        }
-
         let server = NamedPipeServerOptions::new(r"\\.\pipe\virtualdisplaydriver")
             .reject_remote()
             .read_message()
@@ -113,7 +137,14 @@ fn get_data() -> Vec<Monitor> {
 }
 
 fn add(monitors: Vec<Monitor>) {
-    let adapter = ADAPTER.get().unwrap().0.as_ptr();
+    let adapter = {
+        let guard = ADAPTER.lock().unwrap();
+        let Some(a) = guard.as_ref() else {
+            warn!("Cannot add monitors yet; adapter not initialized");
+            return;
+        };
+        a.0.as_ptr()
+    };
 
     unsafe {
         DeviceContext::get_mut(adapter as *mut _, |context| {
@@ -121,7 +152,7 @@ fn add(monitors: Vec<Monitor>) {
                 let id = monitor.id;
 
                 {
-                    let mut lock = MONITOR_MODES.get().unwrap().lock().unwrap();
+                    let mut lock = MONITOR_MODES.lock().unwrap();
 
                     // if this monitor index is already in, do not add it, no-op it
                     if lock.iter().any(|m| m.monitor.id == id) {
@@ -143,7 +174,7 @@ fn add(monitors: Vec<Monitor>) {
 }
 
 fn remove_all() -> Option<ControlFlow<()>> {
-    let mut lock = MONITOR_MODES.get().unwrap().lock().unwrap();
+    let mut lock = MONITOR_MODES.lock().unwrap();
 
     for monitor in lock.drain(..) {
         let Some(mut monitor_object) = monitor.monitor_object else {
@@ -159,7 +190,7 @@ fn remove_all() -> Option<ControlFlow<()>> {
 }
 
 fn remove(ids: Vec<u32>) -> Option<ControlFlow<()>> {
-    let mut lock = MONITOR_MODES.get().unwrap().lock().unwrap();
+    let mut lock = MONITOR_MODES.lock().unwrap();
 
     let mut to_remove = Vec::new();
 


### PR DESCRIPTION
## Problem

`monitor_listener::startup` calls `OnceLock::set(...).unwrap()` for `MONITOR_MODES`, and `callbacks::adapter_init_finished` calls `OnceLock::set(...).unwrap()` for `ADAPTER`. UMDF keeps the WUDFHost.exe process alive across PnP disable+enable (or any pnputil /restart-device cycle), so on the *second* `adapter_init_finished` both `OnceLock::set` calls return `Err` and `.unwrap()` panics the spawning thread silently.

Symptoms I hit while building a phone-as-monitor feature on top of this driver:

- First boot: `vdd_settings.xml` (now `data` reg key) is read, the registered monitor materializes, IPC works.
- Any subsequent `Disable-PnpDevice ROOT\DISPLAY\0001` + `Enable-PnpDevice` *or* `pnputil /restart-device` cycle: registry-driven monitors don't re-spawn, IPC writes silently drop. The PnP device shows `Status: OK / Problem: CM_PROB_NONE` but the driver is effectively dead for monitor-list operations until a full Windows reboot resets the statics.
- Repro is 100% deterministic on Win11 22H2 + AMD GPU + v0.3.1 release; presumably affects any user trying to use the registry-config-then-restart-device pattern as a programmatic monitor add/resize mechanism.

## Fix

Convert both statics to interior-mutable `Mutex`-wrapped state so the second init can repopulate them:

- `pub static ADAPTER: Mutex<Option<AdapterObject>>`
- `pub static MONITOR_MODES: Mutex<Vec<MonitorObject>>`

The pipe-listener thread is now spawned exactly once per process (guarded by `AtomicBool`) — it's process-scoped, not adapter-scoped, and the named pipe stays bound across PnP cycles. Subsequent inits just clear `MONITOR_MODES` and repopulate from the registry; the existing listener thread is reused.

`callbacks::adapter_init_finished` replaces `ADAPTER.set(...).unwrap()` with `*ADAPTER.lock().unwrap() = Some(...)` so a fresh adapter pointer overwrites the stale one from the previous init.

## Scope

- 2 files, +53/-20 lines.
- No public API changes; `pub static ADAPTER` / `pub static MONITOR_MODES` are still re-exported the same way.
- No new dependencies (uses `std::sync::Mutex` + `std::sync::atomic::AtomicBool`, both already in `std`).
- I haven't been able to get the build to complete cleanly in my own environment (bindgen 0.68.1 + Win11 22H2 SDK seems to drop primitive Win32 typedefs in my hands), so this PR is **untested-against-a-running-driver** by me. But the logic is straightforward and your CI should produce a verifiable artifact.

## Verification path (once CI builds)

Two consecutive `Disable-PnpDevice ROOT\DISPLAY\0001 && Enable-PnpDevice ROOT\DISPLAY\0001` cycles in one boot, with a fresh registry `data` value before the second cycle, should both produce a new `\\.\DISPLAY{N}` matching the configured resolution. Before this patch, only the first cycle produces a monitor.